### PR TITLE
Move to 2-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM openjdk:8-jdk-alpine
+FROM maven:3-openjdk-8
+COPY . /src
+WORKDIR /src
+RUN mvn package
+
+FROM openjdk:8-jre-alpine
+COPY --from=0 /src/target/naturalproductsonline-*.jar app.jar
+
 EXPOSE 8091
 VOLUME /tmp
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} app.jar
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
 
 


### PR DESCRIPTION
Hi, 
I did *not* check that this gives a working NPO web server, but the `docker-compose up` spins up the Spring application and then dies somewhere with mongo stuff.
Also, I did *not* update the README.md, but I think it should be fine to just delete some instructions to first run `mvn`.
Yours, 
Steffen

Closes #48